### PR TITLE
Harden extensions: avoid shell restart, add Ghostty support, block zip-slip

### DIFF
--- a/archive-browser.py
+++ b/archive-browser.py
@@ -322,18 +322,22 @@ with libarchive.file_reader(sys.argv[1]) as a:
     return entries
 
 def _extract(archive, names, dst, progress_cb=None, password=""):
-    """Extraction via 7z/unrar avec progression optionnelle."""
-    os.makedirs(dst, exist_ok=True)
+    """Extraction via 7z/unrar avec progression optionnelle.
+
+    Returns None on success, or an error message string if extraction is
+    refused because an archive entry path is unsafe.
+    """
     # Basic Zip-Slip prevention: refuse absolute paths or path traversal.
     # `names` come from inside the archive and must not be treated as trusted.
     for n in names:
         if not n:
             continue
         if n.startswith(("/", "\\")) or re.match(r"^[A-Za-z]:[\\\\/]", n):
-            raise RuntimeError(f"Unsafe absolute path in archive entry: {n!r}")
+            return f"Unsafe absolute path in archive entry: {n!r}"
         # Consider both POSIX and Windows-style separators.
         if ".." in PurePosixPath(n).parts or ".." in PureWindowsPath(n).parts:
-            raise RuntimeError(f"Unsafe path traversal in archive entry: {n!r}")
+            return f"Unsafe path traversal in archive entry: {n!r}"
+    os.makedirs(dst, exist_ok=True)
     if _is_7z_multivolume(archive):
         # 7z gère les volumes automatiquement
         pwd_args = ["-p" + password] if password else []

--- a/archive-browser.py
+++ b/archive-browser.py
@@ -33,6 +33,7 @@ import subprocess
 import tempfile
 import threading
 import locale
+from pathlib import PurePosixPath, PureWindowsPath
 import gi
 gi.require_version("Gtk", "4.0")
 gi.require_version("Adw", "1")
@@ -323,6 +324,16 @@ with libarchive.file_reader(sys.argv[1]) as a:
 def _extract(archive, names, dst, progress_cb=None, password=""):
     """Extraction via 7z/unrar avec progression optionnelle."""
     os.makedirs(dst, exist_ok=True)
+    # Basic Zip-Slip prevention: refuse absolute paths or path traversal.
+    # `names` come from inside the archive and must not be treated as trusted.
+    for n in names:
+        if not n:
+            continue
+        if n.startswith(("/", "\\")) or re.match(r"^[A-Za-z]:[\\\\/]", n):
+            raise RuntimeError(f"Unsafe absolute path in archive entry: {n!r}")
+        # Consider both POSIX and Windows-style separators.
+        if ".." in PurePosixPath(n).parts or ".." in PureWindowsPath(n).parts:
+            raise RuntimeError(f"Unsafe path traversal in archive entry: {n!r}")
     if _is_7z_multivolume(archive):
         # 7z gère les volumes automatiquement
         pwd_args = ["-p" + password] if password else []

--- a/dual-panel.py
+++ b/dual-panel.py
@@ -1049,9 +1049,14 @@ class FilePanel(Gtk.Box):
 
     def _open_terminal(self, _btn):
         target = self._get_target_dir()
-        for term in ["gnome-terminal", "xterm", "konsole", "xfce4-terminal"]:
+        # Prefer Ghostty if installed, then fall back to common terminals.
+        for term in ["ghostty", "gnome-terminal", "xterm", "konsole", "xfce4-terminal"]:
             if shutil.which(term):
-                subprocess.Popen([term], cwd=target)
+                # Ghostty supports `working-directory` as a config key CLI arg.
+                if term == "ghostty":
+                    subprocess.Popen([term, f"--working-directory={target}"])
+                else:
+                    subprocess.Popen([term], cwd=target)
                 return
 
     # -- Menu contextuel clic droit -----------------------------------------

--- a/extensions-manager.py
+++ b/extensions-manager.py
@@ -331,11 +331,24 @@ class ExtManagerWindow(Adw.Window):
         GLib.timeout_add(200, self._restart_nautilus)
 
     def _restart_nautilus(self):
-        # Lancer le nouveau Nautilus en arrière-plan AVANT de tuer l'actuel
-        subprocess.Popen(["bash", "-c",
-            "sleep 0.8 && nautilus &"
-        ])
-        # Tuer proprement le process actuel
+        # Avoid `bash -c`: there is no user input here, but a shell is still an
+        # unnecessary risk surface.
+        #
+        # Start a new Nautilus process in the background before quitting the
+        # current one, to reduce the chance of the user ending up without a
+        # file manager window.
+        try:
+            subprocess.Popen(
+                ["nautilus"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                close_fds=True,
+                start_new_session=True,
+            )
+        except Exception:
+            # If spawning fails, still try to quit the current instance.
+            pass
+        # Quit the current Nautilus cleanly
         subprocess.Popen(["nautilus", "-q"])
         return False
 

--- a/extract-here.py
+++ b/extract-here.py
@@ -34,6 +34,7 @@ import subprocess
 import threading
 import locale
 import tempfile
+from pathlib import PurePosixPath, PureWindowsPath
 
 import gi
 gi.require_version("Gtk", "4.0")
@@ -55,6 +56,7 @@ if _lang.startswith("fr"):
         "done_msg":       "Extrait dans : {dst}",
         "err_7z":         "p7zip est introuvable.\nInstallez-le avec :\nsudo apt install p7zip-full",
         "err_failed":     "L'extraction a échoué (code {code})",
+        "err_unsafe":     "Chemins dangereux détectés dans l'archive (.. ou absolus). Extraction refusée.",
         "err_password":   "Mot de passe incorrect ou archive corrompue.",
         "password_label": "Mot de passe (laisser vide si aucun) :",
         "volumes_found":  "{n} partie(s) détectée(s) — extraction automatique.",
@@ -70,6 +72,7 @@ else:
         "done_msg":       "Extracted to: {dst}",
         "err_7z":         "p7zip not found.\nInstall it with:\nsudo apt install p7zip-full",
         "err_failed":     "Extraction failed (exit code {code})",
+        "err_unsafe":     "Unsafe paths detected in archive (.. or absolute). Refusing to extract.",
         "err_password":   "Wrong password or corrupted archive.",
         "password_label": "Password (leave empty if none):",
         "volumes_found":  "{n} part(s) found — extracting automatically.",
@@ -185,6 +188,34 @@ def _is_encrypted(path: str) -> bool:
         # Méthode AES explicite
         if "Method = AES" in output:
             return True
+        return False
+    except Exception:
+        return False
+
+
+def _archive_has_unsafe_paths(path: str) -> bool:
+    """Best-effort Zip-Slip check using `7z l -slt`.
+    Returns True if it detects absolute paths or '..' traversal in entry names.
+    If listing fails, returns False (cannot prove unsafe)."""
+    try:
+        r = subprocess.run(
+            [SZ_BIN, "l", "-slt", '-p""', path],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if r.returncode != 0:
+            return False
+        for line in r.stdout.splitlines():
+            if not line.startswith("Path = "):
+                continue
+            name = line[len("Path = ") :].strip()
+            if not name:
+                continue
+            if name.startswith(("/", "\\")) or re.match(r"^[A-Za-z]:[\\\\/]", name):
+                return True
+            if ".." in PurePosixPath(name).parts or ".." in PureWindowsPath(name).parts:
+                return True
         return False
     except Exception:
         return False
@@ -396,6 +427,11 @@ class ExtractProgressDialog(Adw.Window):
 
     def _extract(self):
         try:
+            # Zip-Slip hardening (best effort): refuse extraction if archive
+            # advertises absolute paths or traversal entries.
+            if _archive_has_unsafe_paths(self._first_part):
+                raise RuntimeError(T["err_unsafe"])
+
             if _is_double(self._first_part):
                 # Passe 1 : bzip2/gz/xz → .tar
                 tmp_dir = tempfile.mkdtemp(


### PR DESCRIPTION
Changes:\n- extensions-manager: restart Nautilus without bash -c\n- dual-panel: prefer Ghostty and open in target directory\n- archive-browser/extract-here: basic Zip-Slip/path traversal checks to refuse unsafe archive entries\n\nNotes:\n- Passwords are still passed via CLI to 7z/unrar (upstream behavior); this PR does not change that.